### PR TITLE
Use .NET 5 with JsonSerializer

### DIFF
--- a/SerializationTest.Test/SerializationTest.Test.csproj
+++ b/SerializationTest.Test/SerializationTest.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/SerializationTest.Test/SerializationTest.Test.csproj
+++ b/SerializationTest.Test/SerializationTest.Test.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/SerializationTest/DoubleLinkedList.cs
+++ b/SerializationTest/DoubleLinkedList.cs
@@ -20,7 +20,9 @@ namespace SerializationTest
         {
             var newNode = new ListNode
             {
-               // Previous = prevNode,
+                /* it's guaranteed that list provided as an argument to Serialize and DeepCopy 
+                function is consistent and doesn't contain any cycles */
+                // Previous = prevNode,
                 Next = prevNode.Next,
                 Data = payload
             };

--- a/SerializationTest/DoubleLinkedList.cs
+++ b/SerializationTest/DoubleLinkedList.cs
@@ -20,7 +20,7 @@ namespace SerializationTest
         {
             var newNode = new ListNode
             {
-                Previous = prevNode,
+               // Previous = prevNode,
                 Next = prevNode.Next,
                 Data = payload
             };

--- a/SerializationTest/ListSerializer.cs
+++ b/SerializationTest/ListSerializer.cs
@@ -16,16 +16,8 @@ namespace SerializationTest
             var formatter = new BinaryFormatter();
             try
             {
-                var options = new JsonSerializerOptions 
-                {
-                };
-
+                var options = new JsonSerializerOptions { IncludeFields = true };
                 await JsonSerializer.SerializeAsync(s, head, typeof(ListNode), options);
-
-                s.Position = beforeSerialization;
-                var test = await JsonSerializer.DeserializeAsync(s, typeof(ListNode), options);
-
-
             }
             catch
             { // return stream back to it's original state
@@ -41,7 +33,9 @@ namespace SerializationTest
             s.Position = 0;
             try
             {
-                return (ListNode) formatter.Deserialize(s);
+                var options = new JsonSerializerOptions { IncludeFields = true };
+                var res = await JsonSerializer.DeserializeAsync(s, typeof(ListNode), options);
+                return (ListNode) res;
             }
             catch (Exception)
             {
@@ -52,15 +46,14 @@ namespace SerializationTest
         public async Task<ListNode> DeepCopy(ListNode head)
         {
             await using var stream = new MemoryStream();
-            var formatter = new BinaryFormatter
-            {
-                Context = new StreamingContext(StreamingContextStates.Clone),
-            };
+
+            var options = new JsonSerializerOptions { IncludeFields = true };
+            await JsonSerializer.SerializeAsync(stream, head, typeof(ListNode), options);
             
-            formatter.Serialize(stream, head);
             stream.Position = 0;
+            var res = await JsonSerializer.DeserializeAsync(stream, typeof(ListNode), options);
             
-            return (ListNode) formatter.Deserialize(stream);
+            return (ListNode) res;
         }
     }
 }

--- a/SerializationTest/ListSerializer.cs
+++ b/SerializationTest/ListSerializer.cs
@@ -4,6 +4,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
 using SerializationTest.Models;
+using System.Text.Json;
 
 namespace SerializationTest
 {
@@ -15,7 +16,16 @@ namespace SerializationTest
             var formatter = new BinaryFormatter();
             try
             {
-                formatter.Serialize(s,head);
+                var options = new JsonSerializerOptions 
+                {
+                };
+
+                await JsonSerializer.SerializeAsync(s, head, typeof(ListNode), options);
+
+                s.Position = beforeSerialization;
+                var test = await JsonSerializer.DeserializeAsync(s, typeof(ListNode), options);
+
+
             }
             catch
             { // return stream back to it's original state

--- a/SerializationTest/Models/ListNode.cs
+++ b/SerializationTest/Models/ListNode.cs
@@ -2,7 +2,6 @@
 
 namespace SerializationTest.Models
 {
-    [Serializable]
     public  class ListNode
     {
         /// <summary>

--- a/SerializationTest/Program.cs
+++ b/SerializationTest/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using SerializationTest.Models;
 
 namespace SerializationTest
 {
@@ -8,8 +9,31 @@ namespace SerializationTest
     {
         private static async Task Main()
         {
+            var rootNode = CreateLinkedList();
+            
+            var serializer = new ListSerializer();
+            
+            using var stream = new MemoryStream();
+            await serializer.Serialize(rootNode, stream);
+
+            var deserializedNode = serializer.Deserialize(stream).GetAwaiter().GetResult();
             // user code
             Console.ReadLine();
+        }
+
+        private static ListNode CreateLinkedList()
+        {
+            var dll = new DoubleLinkedList();
+            
+            var rootNode = dll.Init("data-0");
+            var prevNode = rootNode;
+            
+            for (var i = 1; i < 10; i++)
+            {
+                prevNode = dll.Add(prevNode, $"data-{i}");
+            }
+
+            return rootNode;
         }
     }
 }

--- a/SerializationTest/Program.cs
+++ b/SerializationTest/Program.cs
@@ -9,31 +9,8 @@ namespace SerializationTest
     {
         private static async Task Main()
         {
-            var rootNode = CreateLinkedList();
-            
-            var serializer = new ListSerializer();
-            
-            using var stream = new MemoryStream();
-            await serializer.Serialize(rootNode, stream);
-
-            var deserializedNode = serializer.Deserialize(stream).GetAwaiter().GetResult();
             // user code
             Console.ReadLine();
-        }
-
-        private static ListNode CreateLinkedList()
-        {
-            var dll = new DoubleLinkedList();
-            
-            var rootNode = dll.Init("data-0");
-            var prevNode = rootNode;
-            
-            for (var i = 1; i < 10; i++)
-            {
-                prevNode = dll.Add(prevNode, $"data-{i}");
-            }
-
-            return rootNode;
         }
     }
 }

--- a/SerializationTest/SerializationTest.csproj
+++ b/SerializationTest/SerializationTest.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Migrate to .NET 5
- Use JsonSerializer instead of obsolete BinaryFormatter